### PR TITLE
Finish implementing redemption status callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,15 @@ serviceX.showOfferDetail(
     //** You need to add your push claim request in this callback and tell the SDK for the result
     try {
       const res = await pushClaim(localId, credifyId);
-      console.log({ res });
       serviceX.setPushClaimRequestStatus(true);
     } catch (error) {
       serviceX.setPushClaimRequestStatus(false);
     }
+  },
+  (result: RedemptionStatus) => {
+    // ** Incase you want to get redemption status or just want to refresh the offer list when user close the SDK popup
+    console.log('**** redemtion result = ' + result);
+    offerListHandler();
   }
 );
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -256,7 +256,7 @@ PODS:
     - Kingfisher
     - lottie-ios
     - MarkdownKit
-  - servicex-rn (0.5.0):
+  - servicex-rn (0.7.0):
     - React-Core
     - serviceX (~> 0.8.7)
   - Yoga (1.14.0)
@@ -391,7 +391,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
   serviceX: b4a1cc25dba3de7ba5267a4bf718ee9c2d5ca9bc
-  servicex-rn: f3eb7fa80e91f2c0088a09ddb282b2c82021b1e5
+  servicex-rn: 6b4114fbe78b6814ffb0c9069b3cc511d6657a77
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 
 PODFILE CHECKSUM: eeda483efd8c01624944d9a0ba7dee38f6c6e5b0

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -13,7 +13,7 @@ import {
   TextInput,
   SafeAreaView,
 } from 'react-native';
-import serviceX, { OfferData } from 'servicex-rn';
+import serviceX, { OfferData, RedemptionStatus } from 'servicex-rn';
 
 const API_KEY =
   '7kx6vx9p9gZmqrtvHjRTOiSXMkAfZB3s5u3yjLehQHQCtjWrjAk9XlQHR2IOqpuR';
@@ -43,12 +43,8 @@ export default function App() {
     showLoading(true);
     try {
       const res = await serviceX.getOffers();
-      const credifyId = res.credifyId;
       const offers = res.offerList;
       setOffers(offers);
-      console.log({ res });
-      console.log({ credifyId });
-      console.log({ offers });
     } catch (error) {
       console.log({ error });
     }
@@ -68,7 +64,6 @@ export default function App() {
     try {
       const res = await fetch(`${DEMO_USER_URL}?id=${idText}`);
       const _user = await res.json();
-      console.log({ _user });
       setUser(_user);
       const userProfile = {
         id: _user.id,
@@ -76,7 +71,6 @@ export default function App() {
         country_code: _user.phoneCountryCode,
         credify_id: _user.credifyId,
       };
-      console.log({ userProfile });
       onChangeText(_user.id);
       serviceX.setUserProfile(userProfile);
     } catch (error) {
@@ -96,6 +90,10 @@ export default function App() {
         } catch (error) {
           serviceX.setPushClaimRequestStatus(false);
         }
+      },
+      (result: RedemptionStatus) => {
+        console.log('**** redemtion result = ' + result);
+        offerListHandler();
       }
     );
   }
@@ -123,7 +121,6 @@ export default function App() {
     return (
       <TouchableOpacity
         onPress={() => {
-          console.log({ item });
           showOfferDetail(item.id!!);
         }}
       >

--- a/ios/ServicexSdkRn.m
+++ b/ios/ServicexSdkRn.m
@@ -1,6 +1,7 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface RCT_EXTERN_MODULE(ServicexSdkRn, NSObject)
+@interface RCT_EXTERN_MODULE(ServicexSdkRn, RCTEventEmitter)
 
 RCT_EXTERN_METHOD(initialize:(NSString *)apiKey environment:(NSString *)environment marketName:(NSString *)marketName packageVersion:(NSString *)packageVersion)
 RCT_EXTERN_METHOD(setUserProfile:(NSDictionary *)userDict)
@@ -10,6 +11,7 @@ RCT_EXTERN_METHOD(showOfferDetail:(NSString *)offerId pushClaimCB:(RCTResponseSe
 RCT_EXTERN_METHOD(showPassport:(RCTResponseSenderBlock)dismissCB)
 RCT_EXTERN_METHOD(setPushClaimRequestStatus:(BOOL)isSuccess)
 RCT_EXTERN_METHOD(appDidBecomeActive:(UIApplication *)application)
+RCT_EXTERN_METHOD(supportedEvents)
 
 @end
 


### PR DESCRIPTION
## Description
When a user finishes the redemption flow, the RN SDK needs to return the transaction status. Because of the limitation of the callback in react native that only one callback can be used in one bridge function so need to use event emitter instead

## Motivation & Context (Clubhouse link)
https://app.shortcut.com/credify/story/20330/react-native-sdk-return-transaction-status-after-finishing-redemption-flow

## How has this been tested?
I tested locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. --->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
